### PR TITLE
feat(hooks): Add message:received and message:sent hook events

### DIFF
--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { GetReplyOptions } from "./types.js";
+import { triggerMessageReceived } from "../hooks/message-hooks.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
@@ -22,6 +23,10 @@ export async function dispatchInboundMessage(params: {
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
+
+  // Trigger message:received hook before processing
+  await triggerMessageReceived(finalized.SessionKey ?? "", finalized);
+
   return await dispatchReplyFromConfig({
     ctx: finalized,
     cfg: params.cfg,

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -149,12 +149,18 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         }
         await options.deliver(normalized, { kind });
 
-        // Trigger message:sent hook after successful delivery
+        // Trigger message:sent hook after successful delivery (fire-and-forget)
+        // Isolated from delivery to avoid marking successful sends as failed
         if (options.hookContext?.sessionKey) {
-          await triggerMessageSent(options.hookContext.sessionKey, normalized, {
+          triggerMessageSent(options.hookContext.sessionKey, normalized, {
             target: options.hookContext.target,
             channel: options.hookContext.channel,
             kind,
+          }).catch((err) => {
+            console.error(
+              "[message:sent hook] Error:",
+              err instanceof Error ? err.message : String(err),
+            );
           });
         }
       })

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -2,6 +2,7 @@ import type { HumanDelayConfig } from "../../config/types.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { ResponsePrefixContext } from "./response-prefix-template.js";
 import type { TypingController } from "./typing.js";
+import { triggerMessageSent } from "../../hooks/message-hooks.js";
 import { sleep } from "../../utils.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
 
@@ -53,6 +54,12 @@ export type ReplyDispatcherOptions = {
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
+  /** Hook context for message:sent events */
+  hookContext?: {
+    sessionKey?: string;
+    channel?: string;
+    target?: string;
+  };
 };
 
 export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onIdle"> & {
@@ -141,6 +148,15 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           }
         }
         await options.deliver(normalized, { kind });
+
+        // Trigger message:sent hook after successful delivery
+        if (options.hookContext?.sessionKey) {
+          await triggerMessageSent(options.hookContext.sessionKey, normalized, {
+            target: options.hookContext.target,
+            channel: options.hookContext.channel,
+            kind,
+          });
+        }
       })
       .catch((err) => {
         options.onError?.(err, { kind });

--- a/src/hooks/hooks.ts
+++ b/src/hooks/hooks.ts
@@ -1,4 +1,5 @@
 export * from "./internal-hooks.js";
+export * from "./message-hooks.js";
 
 export type HookEventType = import("./internal-hooks.js").InternalHookEventType;
 export type HookEvent = import("./internal-hooks.js").InternalHookEvent;

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,7 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;

--- a/src/hooks/message-hooks.test.ts
+++ b/src/hooks/message-hooks.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FinalizedMsgContext } from "../auto-reply/templating.js";
+import {
+  registerInternalHook,
+  clearInternalHooks,
+  type InternalHookEvent,
+} from "./internal-hooks.js";
+import {
+  triggerMessageReceived,
+  triggerMessageSent,
+  type MessageReceivedContext,
+  type MessageSentContext,
+} from "./message-hooks.js";
+
+describe("message-hooks", () => {
+  beforeEach(() => {
+    clearInternalHooks();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+  });
+
+  describe("triggerMessageReceived", () => {
+    it("triggers message:received hook with correct context", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:received", handler);
+
+      const ctx = {
+        Body: "Hello world",
+        RawBody: "Hello world",
+        SenderId: "+1234567890",
+        SenderName: "Test User",
+        Provider: "signal",
+        MessageSid: "msg123",
+        ChatType: "direct",
+        From: "signal:+1234567890",
+        Timestamp: 1234567890,
+        CommandAuthorized: true,
+        SessionKey: "agent:main:main",
+      } as FinalizedMsgContext;
+
+      await triggerMessageReceived("agent:main:main", ctx);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const event = handler.mock.calls[0][0] as InternalHookEvent;
+      expect(event.type).toBe("message");
+      expect(event.action).toBe("received");
+      expect(event.sessionKey).toBe("agent:main:main");
+
+      const context = event.context as MessageReceivedContext;
+      expect(context.message).toBe("Hello world");
+      expect(context.senderId).toBe("+1234567890");
+      expect(context.channel).toBe("signal");
+    });
+
+    it("triggers both general and specific handlers", async () => {
+      const generalHandler = vi.fn();
+      const specificHandler = vi.fn();
+      registerInternalHook("message", generalHandler);
+      registerInternalHook("message:received", specificHandler);
+
+      const ctx = {
+        Body: "Test",
+        SessionKey: "test-session",
+      } as FinalizedMsgContext;
+
+      await triggerMessageReceived("test-session", ctx);
+
+      expect(generalHandler).toHaveBeenCalledTimes(1);
+      expect(specificHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("triggerMessageSent", () => {
+    it("triggers message:sent hook with correct context", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:sent", handler);
+
+      const payload = { text: "Hello back!" };
+      const context = {
+        target: "signal:+1234567890",
+        channel: "signal",
+        kind: "final",
+      };
+
+      await triggerMessageSent("agent:main:main", payload, context);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const event = handler.mock.calls[0][0] as InternalHookEvent;
+      expect(event.type).toBe("message");
+      expect(event.action).toBe("sent");
+      expect(event.sessionKey).toBe("agent:main:main");
+
+      const eventContext = event.context as MessageSentContext;
+      expect(eventContext.text).toBe("Hello back!");
+      expect(eventContext.target).toBe("signal:+1234567890");
+      expect(eventContext.channel).toBe("signal");
+      expect(eventContext.kind).toBe("final");
+    });
+
+    it("handles payload with media", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message:sent", handler);
+
+      const payload = {
+        text: "Check this out",
+        mediaUrl: "/tmp/image.png",
+      };
+
+      await triggerMessageSent("test-session", payload, { channel: "telegram" });
+
+      const event = handler.mock.calls[0][0] as InternalHookEvent;
+      const context = event.context as MessageSentContext;
+      expect(context.mediaUrl).toBe("/tmp/image.png");
+    });
+  });
+});

--- a/src/hooks/message-hooks.ts
+++ b/src/hooks/message-hooks.ts
@@ -1,0 +1,91 @@
+/**
+ * Message hook events for message:received and message:sent
+ *
+ * These hooks enable automation around the message lifecycle:
+ * - message:received — fires when an inbound message is about to be processed
+ * - message:sent — fires after an outbound message is successfully delivered
+ */
+
+import type { FinalizedMsgContext } from "../auto-reply/templating.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+
+export type MessageReceivedContext = {
+  /** The finalized inbound message context */
+  message: string;
+  /** Raw message body before envelope formatting */
+  rawBody?: string;
+  /** Sender identifier (phone, username, etc.) */
+  senderId?: string;
+  /** Sender display name */
+  senderName?: string;
+  /** Channel the message came from (signal, telegram, etc.) */
+  channel?: string;
+  /** Platform message ID */
+  messageId?: string;
+  /** Whether this is a group message */
+  isGroup?: boolean;
+  /** Group ID if applicable */
+  groupId?: string;
+  /** Timestamp of the message */
+  timestamp?: number;
+  /** Whether the sender is authorized for commands */
+  commandAuthorized?: boolean;
+};
+
+export type MessageSentContext = {
+  /** The reply text that was sent */
+  text?: string;
+  /** Media URL if any */
+  mediaUrl?: string;
+  /** Target recipient */
+  target?: string;
+  /** Channel the message was sent to */
+  channel?: string;
+  /** Delivery kind (tool, block, final) */
+  kind?: string;
+};
+
+/**
+ * Trigger message:received hook
+ * Call this when an inbound message is about to be processed by the agent
+ */
+export async function triggerMessageReceived(
+  sessionKey: string,
+  ctx: FinalizedMsgContext,
+): Promise<void> {
+  const hookEvent = createInternalHookEvent("message", "received", sessionKey, {
+    message: ctx.Body ?? "",
+    rawBody: ctx.RawBody,
+    senderId: ctx.SenderId,
+    senderName: ctx.SenderName,
+    channel: ctx.Provider,
+    messageId: ctx.MessageSid,
+    isGroup: ctx.ChatType === "group",
+    groupId: ctx.ChatType === "group" ? ctx.From : undefined,
+    timestamp: ctx.Timestamp,
+    commandAuthorized: ctx.CommandAuthorized,
+  } satisfies MessageReceivedContext);
+
+  await triggerInternalHook(hookEvent);
+}
+
+/**
+ * Trigger message:sent hook
+ * Call this after an outbound message is successfully delivered
+ */
+export async function triggerMessageSent(
+  sessionKey: string,
+  payload: ReplyPayload,
+  context: { target?: string; channel?: string; kind?: string },
+): Promise<void> {
+  const hookEvent = createInternalHookEvent("message", "sent", sessionKey, {
+    text: payload.text,
+    mediaUrl: payload.mediaUrl,
+    target: context.target,
+    channel: context.channel,
+    kind: context.kind,
+  } satisfies MessageSentContext);
+
+  await triggerInternalHook(hookEvent);
+}

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -218,6 +218,12 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         deps.runtime.error?.(danger(`signal ${info.kind} reply failed: ${String(err)}`));
       },
       onReplyStart: typingCallbacks.onReplyStart,
+      // Hook context for message:sent events
+      hookContext: {
+        sessionKey: route.sessionKey,
+        channel: "signal",
+        target: ctxPayload.To,
+      },
     });
 
     const { queuedFinal } = await dispatchInboundMessage({


### PR DESCRIPTION
Implements the planned message hook events from the hooks documentation.

## Changes
- Add 'message' to InternalHookEventType
- Create message-hooks.ts with triggerMessageReceived and triggerMessageSent helpers  
- Trigger message:received in dispatch.ts before agent processing
- Trigger message:sent in reply-dispatcher.ts after successful delivery
- Add hookContext option to ReplyDispatcherOptions for session/channel context
- Update Signal channel to pass hookContext (example for other channels)
- Add unit tests for message hooks

## Testing
- Unit tests added for message-hooks.ts
- Tested locally with semantic-recall and memory-extract hooks

Closes #5053