### PR TITLE
refactor: move blocking logic out of core into hook handler

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -173,16 +173,8 @@ export async function spawnSubagentDirect(
   const hookEvent = createInternalHookEvent("session", "pre-spawn", childSessionKey, hookContext);
   await triggerInternalHook(hookEvent);
 
-  // Check if hook blocked the spawn
-  const mutatedContext = hookEvent.context as SessionPreSpawnHookContext;
-  if (mutatedContext.blocked) {
-    return {
-      status: "error",
-      error: mutatedContext.blockReason || "Spawn blocked by hook",
-    };
-  }
-
   // Read back hook-mutated values
+  const mutatedContext = hookEvent.context as SessionPreSpawnHookContext;
   modelOverrideFromHook = mutatedContext.model;
   thinkingOverrideRawFromHook = mutatedContext.thinking;
   fallbackModelFromHook = mutatedContext.fallbackModel;

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -546,28 +546,8 @@ export const agentHandlers: GatewayRequestHandlers = {
     const hookEvent = createInternalHookEvent("agent", "pre-run", resolvedSessionKey, hookContext);
     await triggerInternalHook(hookEvent);
 
-    // Check if hook blocked the run
-    const mutatedContext = hookEvent.context as AgentPreRunHookContext;
-    if (mutatedContext.blocked) {
-      const error = errorShape(
-        ErrorCodes.INVALID_REQUEST,
-        mutatedContext.blockReason || "Agent run blocked by hook",
-      );
-      context.dedupe.set(`agent:${idem}`, {
-        ts: Date.now(),
-        ok: false,
-        payload: {
-          runId,
-          status: "error" as const,
-          summary: error.message,
-        },
-        error,
-      });
-      respond(false, undefined, error);
-      return;
-    }
-
     // Read back hook-mutated values
+    const mutatedContext = hookEvent.context as AgentPreRunHookContext;
     thinkingFromHook = mutatedContext.thinking;
     modelFromHook = mutatedContext.model;
 

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -508,28 +508,6 @@ describe("hooks", () => {
       expect(mutatedContext.thinking).toBe("low");
       expect(mutatedContext.fallbackModel).toBe("claude-haiku");
     });
-
-    it("should allow hooks to block spawn", async () => {
-      const handler = vi.fn((event) => {
-        const ctx = event.context as SessionPreSpawnHookContext;
-        if (!ctx.agentId) {
-          ctx.blocked = true;
-          ctx.blockReason = "agentId is required";
-        }
-      });
-      registerInternalHook("session:pre-spawn", handler);
-
-      const context: SessionPreSpawnHookContext = {
-        model: "gpt-4o",
-      };
-      const event = createInternalHookEvent("session", "pre-spawn", "test-session", context);
-      await triggerInternalHook(event);
-
-      expect(handler).toHaveBeenCalled();
-      const mutatedContext = event.context as SessionPreSpawnHookContext;
-      expect(mutatedContext.blocked).toBe(true);
-      expect(mutatedContext.blockReason).toBe("agentId is required");
-    });
   });
 
   describe("agent:pre-run hooks", () => {
@@ -587,28 +565,6 @@ describe("hooks", () => {
 
       expect(generalHandler).toHaveBeenCalledWith(event);
       expect(specificHandler).toHaveBeenCalledWith(event);
-    });
-
-    it("should allow hooks to block agent run", async () => {
-      const handler = vi.fn((event) => {
-        const ctx = event.context as AgentPreRunHookContext;
-        if (!ctx.agentId) {
-          ctx.blocked = true;
-          ctx.blockReason = "agentId is required for agent run";
-        }
-      });
-      registerInternalHook("agent:pre-run", handler);
-
-      const context: AgentPreRunHookContext = {
-        model: "claude-sonnet-4-20250514",
-      };
-      const event = createInternalHookEvent("agent", "pre-run", "test-session", context);
-      await triggerInternalHook(event);
-
-      expect(handler).toHaveBeenCalled();
-      const mutatedContext = event.context as AgentPreRunHookContext;
-      expect(mutatedContext.blocked).toBe(true);
-      expect(mutatedContext.blockReason).toBe("agentId is required for agent run");
     });
   });
 });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -96,10 +96,6 @@ export type SessionPreSpawnHookContext = {
   task?: string;
   /** Session key of the requester/parent agent */
   requesterSessionKey?: string;
-  /** Flag to block spawn (hooks can set this to true) */
-  blocked?: boolean;
-  /** Reason for blocking (set when blocked=true) */
-  blockReason?: string;
 };
 
 export type SessionPreSpawnHookEvent = InternalHookEvent & {
@@ -121,10 +117,6 @@ export type AgentPreRunHookContext = {
   model?: string;
   /** Thinking level (can be mutated by hooks) */
   thinking?: string;
-  /** Flag to block run (hooks can set this to true) */
-  blocked?: boolean;
-  /** Reason for blocking (set when blocked=true) */
-  blockReason?: string;
 };
 
 export type AgentPreRunHookEvent = InternalHookEvent & {


### PR DESCRIPTION
Remove blocking logic from core platform code (subagent-spawn.ts and agent.ts). The blocked flag checking belongs in the hook handler (nova-cognition), not in the core.