### PR TITLE
fix: re-apply agent identity env vars after upstream merge

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -363,18 +363,32 @@ export function createExecTool(
       const inheritedBaseEnv = coerceEnv(process.env);
       const baseEnv = host === "sandbox" ? inheritedBaseEnv : sanitizeHostBaseEnv(inheritedBaseEnv);
 
+      // Inject agent environment variables for subagent sessions
+      const agentEnvVars: Record<string, string> = {};
+      if (agentId) {
+        agentEnvVars.OPENCLAW_AGENT_ID = agentId;
+        agentEnvVars.CLAWDBOT_AGENT_ID = agentId;
+      }
+      if (defaults?.sessionKey) {
+        agentEnvVars.OPENCLAW_SESSION_KEY = defaults.sessionKey;
+      }
+
       // Logic: Sandbox gets raw env. Host (gateway/node) must pass validation.
       // We validate BEFORE merging to prevent any dangerous vars from entering the stream.
       if (host !== "sandbox" && params.env) {
         validateHostEnv(params.env);
       }
 
-      const mergedEnv = params.env ? { ...baseEnv, ...params.env } : baseEnv;
+      // Merge order: process.env <- agentEnvVars <- params.env (user can override agent vars)
+      const mergedEnv = params.env
+        ? { ...baseEnv, ...agentEnvVars, ...params.env }
+        : { ...baseEnv, ...agentEnvVars };
 
       const env = sandbox
         ? buildSandboxEnv({
             defaultPath: DEFAULT_PATH,
             paramsEnv: params.env,
+            agentEnvVars,
             sandboxEnv: sandbox.env,
             containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
           })


### PR DESCRIPTION
Re-applies OPENCLAW_AGENT_ID/CLAWDBOT_AGENT_ID/OPENCLAW_SESSION_KEY injection from original PR #13, lost during upstream merge. Same logic, updated for refactored file structure.