### PR TITLE
fix(outbound): make sendMedia truly optional for text-only channel plugins (#32)

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1012,7 +1012,7 @@ describe("deliverOutboundPayloads", () => {
 
       expect(sendText).not.toHaveBeenCalled();
       expect(results).toHaveLength(1);
-      expect(results[0]).toMatchObject({ ok: true });
+      expect(results[0]).toMatchObject({ channel: "agent_chat", messageId: "" });
     });
 
     it("TC-4: plugin with neither sendText nor sendMedia is rejected", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -188,7 +188,7 @@ function createPluginHandler(
       }
       // Text-only plugin: fall back to sendText with the caption, dropping the media URL.
       if (!caption) {
-        return { ok: true } as OutboundDeliveryResult;
+        return { channel: params.channel, messageId: "" } as OutboundDeliveryResult;
       }
       return sendText({
         ...resolveCtx(overrides),


### PR DESCRIPTION
## Problem

`createPluginHandler()` in `src/infra/outbound/deliver.ts` required both `sendText` AND `sendMedia`:

```ts
if (!outbound?.sendText || !outbound?.sendMedia) {
  return null;
}
```

Despite the `ChannelOutboundAdapter` type marking `sendMedia` as optional (`sendMedia?:`), and the plugin documentation showing a minimal channel example with only `sendText`, the runtime check rejected any plugin missing `sendMedia`. This made the entire outbound handler `null`, blocking ALL outbound — including pure text sends.

## Our Use Case

We have an `agent_chat` channel plugin for inter-agent messaging over PostgreSQL. This is a text-only channel — agents communicate via database rows, not media files. The plugin correctly implements `sendText` (inserting a row into the `agent_messages` table) but has no `sendMedia` because media delivery doesn't apply to database-backed messaging.

Because of this bug, every attempt to send via agent_chat failed with:
```
Error: Outbound not configured for channel: agent_chat
```

This blocked:
- Cron job delivery to agent_chat recipients
- Subagent completion announcements via agent_chat
- Direct inter-agent messaging via the `message` tool

Any custom text-only channel plugin (IRC bridges, inter-agent messaging, webhook-only channels, etc.) would hit the same issue.

## Fix

In `createPluginHandler()`:
- Changed guard to only require `sendText`: `if (!outbound?.sendText) return null;`
- When `sendMedia` is absent and media delivery is attempted, a fallback sends the caption text via `sendText`, silently dropping the media URL
- When caption is empty (media-only payload on a text-only channel), returns a no-op result
- When `sendMedia` IS present, uses the plugin's implementation unchanged — zero behavior change for existing channels

This aligns the runtime behavior with the type definition and the documented minimal channel plugin pattern.

## Changes

**`src/infra/outbound/deliver.ts`**
- `createPluginHandler()`: Only require `sendText`; synthesize `sendMedia` fallback for text-only channels

**`src/infra/outbound/deliver.test.ts`**
- 5 new tests in "text-only channel plugins (sendMedia absent)" block:
  - TC-1: Text-only plugin can send text
  - TC-2: Falls back to sendText for media with caption
  - TC-3: Empty caption media returns no-op result
  - TC-4: Plugin with neither method is rejected
  - TC-5: Plugin with both uses plugin's own sendMedia (no regression)

**`docs/tools/plugin.md`** + **`docs/zh-CN/tools/plugin.md`**
- Added callout clarifying `sendMedia` is optional for text-only channels

**`docs/zh-CN/channels/tlon.md`**
- Fixed stale note about image delivery (was inaccurate vs English docs)

## Testing

- All 264 outbound tests pass (including 5 new)
- Tested on staging (nova-staging) — full integration
- Deployed to production and verified: agent_chat outbound now works

Closes #32

---

**Upstream issue:** openclaw/openclaw#32711