### PR TITLE
fix: Use canonical pipeline for message:received internal hooks (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Hooks/message:received: canonical context pipeline** (#41) — `triggerMessageReceived` now uses the canonical two-step pipeline: `deriveInboundMessageHookContext(ctx)` → `toInternalMessageReceivedContext(canonical)`. Previously it built a hand-rolled context with non-standard field names (`message` instead of `content`, `channel` instead of `provider`/`channelId`). The new pipeline produces a consistent context with sender fields at the top level (`senderId`, `senderName`, `senderUsername`, `senderE164`) and provider metadata in `context.metadata`. The legacy `MessageReceivedContext` type is kept with `@deprecated` for backward compatibility. **Breaking change:** hooks reading `event.context.message` must migrate to `event.context.content`. New file: `src/hooks/message-hooks.ts` extracted `triggerMessageReceived` and `triggerMessageSent` into a dedicated module.
+
 - ACP sessions: map canonical runtime options to backend-advertised ACP config keys like Claude's `effort` while keeping persisted OpenClaw state canonical. (#79926) Thanks @InTheCloudDan.
 - Gateway/watch: rebuild or restage missing bundled-plugin dist and runtime-postbuild outputs before launching the Gateway from a source checkout, preventing incomplete watch-mode runtime trees. (#70805) Thanks @rubencu.
 - CLI/update: allow restart health probes from the previous gateway protocol during self-update, and make plugin dry-runs report exact npm target versions instead of `unknown` while preserving unchanged status.

--- a/src/hooks/message-hooks.ts
+++ b/src/hooks/message-hooks.ts
@@ -1,0 +1,91 @@
+/**
+ * Message hook events for message:received and message:sent
+ *
+ * These hooks enable automation around the message lifecycle:
+ * - message:received — fires when an inbound message is about to be processed
+ * - message:sent — fires after an outbound message is successfully delivered
+ */
+import type { FinalizedMsgContext } from "../auto-reply/templating.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+import {
+  deriveInboundMessageHookContext,
+  toInternalMessageReceivedContext,
+} from "./message-hook-mappers.js";
+
+/**
+ * @deprecated Use CanonicalInboundMessageHookContext from message-hook-mappers.ts
+ * Kept as a type alias for backward compatibility. Downstream hooks should migrate
+ * to reading `content` (not `message`) and canonical field names. See issue #41.
+ */
+export type MessageReceivedContext = {
+  /** @deprecated Use `content` instead */
+  message: string;
+  /** @deprecated Use `content` instead */
+  rawBody?: string;
+  senderId?: string;
+  senderName?: string;
+  /** @deprecated Use `provider` or `channelId` instead */
+  channel?: string;
+  messageId?: string;
+  isGroup?: boolean;
+  groupId?: string;
+  timestamp?: number;
+  commandAuthorized?: boolean;
+};
+
+export type MessageSentContext = {
+  /** The reply text that was sent */
+  text?: string;
+  /** Media URL if any */
+  mediaUrl?: string;
+  /** Target recipient */
+  target?: string;
+  /** Channel the message was sent to */
+  channel?: string;
+  /** Delivery kind (tool, block, final) */
+  kind?: string;
+};
+
+/**
+ * Trigger message:received hook
+ * Call this when an inbound message is about to be processed by the agent.
+ *
+ * Uses the canonical CanonicalInboundMessageHookContext shape (deriveInboundMessageHookContext)
+ * so that hook authors see a consistent context with sender fields at the top level.
+ * Fixes #41: previously used a hand-rolled context with different field names
+ * (e.g. `message` instead of `content`, `channel` instead of `provider`/`channelId`).
+ */
+export async function triggerMessageReceived(
+  sessionKey: string,
+  ctx: FinalizedMsgContext,
+): Promise<void> {
+  const canonical = deriveInboundMessageHookContext(ctx);
+  const internalContext = toInternalMessageReceivedContext(canonical);
+  const hookEvent = createInternalHookEvent("message", "received", sessionKey, internalContext);
+  await triggerInternalHook(hookEvent);
+}
+
+/**
+ * Trigger message:sent hook
+ * Call this after an outbound message is successfully delivered
+ */
+export async function triggerMessageSent(
+  sessionKey: string,
+  payload: ReplyPayload,
+  context: {
+    target?: string;
+    channel?: string;
+    kind?: string;
+  },
+): Promise<void> {
+  await triggerInternalHook(
+    createInternalHookEvent("message", "sent", sessionKey, {
+      text: payload.text,
+      mediaUrl: payload.mediaUrl,
+      target: context.target,
+      channel: context.channel,
+      kind: context.kind,
+    }),
+  );
+}

--- a/tests/TEST-CASES-ISSUE-41.md
+++ b/tests/TEST-CASES-ISSUE-41.md
@@ -1,0 +1,89 @@
+# Test Cases: Issue #41 — Canonical message:received Hook Context
+
+**Branch:** `fix/issue-41-canonical-message-received-context`
+**Related:** nova-mind #179 (parallel fix for sender fields)
+
+---
+
+## Context Shape Consistency
+
+### TC-001: message:received uses deriveInboundMessageHookContext
+
+**Verification:** `triggerMessageReceived` in `src/hooks/message-hooks.ts` calls `deriveInboundMessageHookContext(ctx)` instead of building a custom context object.
+**Expected:** The `createInternalHookEvent` call passes the canonical context, not the hand-rolled one.
+
+### TC-002: Sender fields at top level
+
+**Input:** Discord message from I)ruid
+**Expected:** Hook context has `senderId`, `senderName`, `senderUsername` at the top level (not only inside `metadata`).
+
+```typescript
+event.context.senderId === "330189773371080716";
+event.context.senderName === "I)ruid";
+event.context.senderUsername === "druidian";
+```
+
+### TC-003: Content field present
+
+**Input:** Any message with body text
+**Expected:** `event.context.content` contains the message body (derived from BodyForCommands → RawBody → Body fallback chain).
+
+### TC-004: Provider and channel fields
+
+**Input:** Discord channel message
+**Expected:**
+
+- `event.context.provider === "discord"`
+- `event.context.channelId === "discord"` (normalized)
+- `event.context.conversationId` set to channel identifier
+- `event.context.guildId` set to Discord guild ID
+- `event.context.channelName` set to channel name
+- `event.context.isGroup` correctly determined
+
+### TC-005: Signal message context
+
+**Input:** Signal group message
+**Expected:** Same canonical shape — `provider`, `senderId`, `senderName`, `senderE164`, `isGroup`, `conversationId` all populated at top level.
+
+### TC-006: Telegram message context
+
+**Input:** Telegram message
+**Expected:** Same canonical shape with appropriate provider-specific fields.
+
+### TC-007: messageId populated
+
+**Input:** Any channel message
+**Expected:** `event.context.messageId` contains the platform message ID (from MessageSidFull → MessageSid → MessageSidFirst fallback).
+
+### TC-008: threadId populated for Discord threads
+
+**Input:** Discord message in a thread
+**Expected:** `event.context.threadId` contains the thread ID.
+
+---
+
+## Backward Compatibility
+
+### TC-009: Old context fields still accessible
+
+**Verification:** The canonical context includes `body` (from `ctx.Body`) and `content` (derived). Hooks that previously read `ctx.message` or `ctx.rawBody` should be updated, but the canonical context provides equivalent data via `content`.
+**Expected:** No hook that reads `event.context.content` breaks.
+
+### TC-010: message field deprecated but present
+
+**Verification:** If any downstream hooks depend on `event.context.message` (the old field), consider whether to include it as an alias.
+**Expected:** Document breaking change if `message` field is removed. Prefer `content` going forward.
+
+---
+
+## No Regression
+
+### TC-011: reply_dispatch hooks unaffected
+
+**Verification:** Changes are only to `triggerMessageReceived`. Plugin hooks on `reply_dispatch` continue to receive the same context.
+**Expected:** No change to reply_dispatch behavior.
+
+### TC-012: message:sent hooks unaffected
+
+**Verification:** `triggerMessageSent` is not modified.
+**Expected:** No change to sent message hook behavior.


### PR DESCRIPTION
## Summary

Updates `triggerMessageReceived` to use the canonical two-step pipeline instead of a hand-rolled context object.

### Changes
- **src/hooks/message-hooks.ts**: `triggerMessageReceived` now calls `deriveInboundMessageHookContext(ctx)` → `toInternalMessageReceivedContext(canonical)` — matching what the dispatch code already does.
- **MessageReceivedContext** type kept with `@deprecated` JSDoc for backward compatibility.

### Breaking change
Hooks reading `event.context.message` must migrate to `event.context.content`. The old `message`, `rawBody`, and `channel` fields are no longer in the runtime context.

### Testing
- 12 test cases (TC-001 through TC-012)
- Phase 1 desk review: PASS (Gem on Sonnet 4.6)
- Phase 2 staging: PASS (clean build, gateway starts with all hooks loaded, live Telegram message processed correctly)

### Related
- nova-mind #179 (sender field metadata fallbacks — the consumer-side fix)

Closes #41