### PR TITLE
fix(ci): remove duplicate shell keys in reusable live-checks workflow

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2242,7 +2242,6 @@ jobs:
 
       - name: Run ${{ matrix.label }}
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-src-gateway-profiles-anthropic' && startsWith(matrix.suite_id, 'native-live-src-gateway-profiles-anthropic-')) || (inputs.live_suite_filter == 'native-live-src-gateway-profiles-opencode-go' && startsWith(matrix.suite_id, 'native-live-src-gateway-profiles-opencode-go-')))
-        shell: bash
         env:
           OPENCLAW_LIVE_COMMAND: ${{ matrix.command }}
           OPENCLAW_LIVE_SUITE_ADVISORY: ${{ matrix.advisory }}
@@ -2462,7 +2461,6 @@ jobs:
 
       - name: Run ${{ matrix.label }}
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'live-gateway-advisory-docker' && startsWith(matrix.suite_id, 'live-gateway-advisory-docker-')))
-        shell: bash
         env:
           OPENCLAW_LIVE_COMMAND: ${{ matrix.command }}
           OPENCLAW_LIVE_SUITE_ADVISORY: ${{ matrix.advisory }}
@@ -2652,7 +2650,6 @@ jobs:
 
       - name: Run ${{ matrix.label }}
         if: contains(matrix.profiles, inputs.release_test_profile) && (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id || (inputs.live_suite_filter == 'native-live-extensions-media-video' && startsWith(matrix.suite_id, 'native-live-extensions-media-video-')))
-        shell: bash
         env:
           OPENCLAW_LIVE_SUITE_ADVISORY: ${{ matrix.advisory }}
         shell: bash


### PR DESCRIPTION
## Summary

Three `Run ${{ matrix.label }}` steps in `openclaw-live-and-e2e-checks-reusable.yml` had duplicate `shell: bash` keys in the same YAML step mapping. GitHub Actions now rejects workflows with duplicate mapping keys at the step level, causing the `openclaw-scheduled-live-checks` workflow to fail with "workflow file issue" (0 jobs created, 0s duration).

## Root Cause

Introduced in the `v2026.5.26` tag merge (commit ce49e74627, May 28). Each affected step had:
```yaml
      - name: Run ${{ matrix.label }}
        shell: bash          # ← duplicate (removed)
        env:
          ...
        shell: bash           # ← kept
        run: |
```

## Fix

Remove the first (redundant) `shell: bash` from each of the three affected steps in:
- `validate_live_provider_suites`
- `validate_live_docker_provider_suites`
- `validate_live_media_provider_suites`

This matches the fix already applied in upstream `openclaw/openclaw` main.

## Impact

~20 consecutive daily scheduled check failures since May 28. This is a 3-line deletion with zero behavioral change (YAML last-key-wins was already selecting the correct value).

Fixes #75