### PR TITLE
fix: sync npm-shrinkwrap.json version with package.json -nova suffix

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw",
-  "version": "2026.6.9",
+  "version": "2026.6.9-nova",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw",
-      "version": "2026.6.9",
+      "version": "2026.6.9-nova",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes CI installer_smoke failure red for 5+ days. Both .version and .packages[""].version in npm-shrinkwrap.json now match package.json 2026.6.9-nova. Closes #82