### PR TITLE
fix: remove duplicate memoryCoreAlias import (#84)

### DIFF
--- a/src/plugin-sdk/memory-host-core.test.ts
+++ b/src/plugin-sdk/memory-host-core.test.ts
@@ -11,7 +11,6 @@ import {
   registerMemoryPromptSection,
 } from "../plugins/memory-state.js";
 import * as memoryCoreAlias from "./memory-core.js";
-import * as memoryCoreAlias from "./memory-core.js";
 import {
   buildActiveMemoryPromptSection,
   listMemoryHostPublicArtifacts,


### PR DESCRIPTION
Closes #84

Removes the duplicate `import * as memoryCoreAlias from "./memory-core.js";` line that was causing a PARSE_ERROR in the `checks-node-agentic-plugin-sdk` CI job.