### PR TITLE
docs(skills): upstream github + xurl SKILL.md drift from production (task #448)

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -47,6 +47,8 @@ gh pr merge 55 --repo owner/repo --squash
 
 URLs work directly: `gh pr view https://github.com/owner/repo/pull/55`.
 
+**PR reviews on NOVA-Openclaw repos:** `@clawsweeper` is the upstream openclaw/openclaw review bot and is NOT installed on the NOVA-Openclaw org (zero comments org-wide, verified 2026-07-04). @mentioning it is a silent dead letter. Route PR reviews internally to Gem (QA) as a subagent task; findings get posted as PR comments.
+
 ## Issues
 
 ```bash

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -73,6 +73,8 @@ xurl dms -n 10
 
 `POST_ID` can be a full `https://x.com/<user>/status/<id>` URL.
 
+> **⚠️ Reply/quote tier gating (Feb 2026):** X blocks programmatic `reply`/`quote` on ALL self-serve tiers (Free, Basic, Pro, pay-per-use) unless the target's author mentioned you or quoted your post — 403 "You can only reply to or quote posts where you are mentioned or are the author." Only Enterprise is exempt. This is NOT the author's reply-settings. Workaround: standalone `xurl post` with the target URL appended (renders a quote card, but does not notify the author). (Lesson 770.)
+
 ## Media
 
 > **⚠️ Auto-detection defaults to video (`--category amplify_video --media-type video/mp4`), not image.** Always specify type explicitly for images to avoid upload failures.
@@ -120,6 +122,8 @@ xurl '/2/tweets/search/recent?query=openclaw&max_results=10'
 ```
 
 Use raw mode when shortcuts do not cover the endpoint. Keep payloads in temp files for complex JSON.
+
+> **⚠️ No `get` subcommand (v1.0.4+):** raw calls are `xurl /2/path` directly. `xurl get /2/path` sends the request to a literal `/get` endpoint and 404s.
 
 ## Output and errors
 


### PR DESCRIPTION
## Summary
Ports two pieces of doc-only drift that had accumulated in the production checkout (`~/nova-openclaw-production`) back into the tracked repo, keeping production and repo skill docs in sync.

### `skills/github/SKILL.md` (+2 lines)
Documents that `@clawsweeper` (the upstream openclaw/openclaw review bot) is NOT installed on the NOVA-Openclaw org — @mentioning it is a silent dead letter (verified 2026-07-04, zero comments org-wide). Redirects PR review routing to Gem (QA) as a subagent task instead.

### `skills/xurl/SKILL.md` (+4 lines)
- Reply/quote tier-gating warning (Feb 2026): X blocks programmatic reply/quote on all self-serve tiers unless the target author mentioned/quoted you first — 403 error. Workaround documented (standalone `xurl post` with target URL appended). References **lesson 770**.
- Notes that raw-mode calls are `xurl /2/path` directly — there is no `get` subcommand; `xurl get /2/path` 404s.

Precedent for this upstream-drift pattern: commit d950e917e4c / PR #80 (xurl media-defaults gotcha).

## Task
task #448 — Upstream uncommitted skill-file drift via docs PRs

**Docs-only change. Do not merge — pending NOVA review.**